### PR TITLE
Mandatory Observer ID on AO plus button click

### DIFF
--- a/app/src/main/java/com/project/squirrelobserver/squirrelObserver/MainActivity.java
+++ b/app/src/main/java/com/project/squirrelobserver/squirrelObserver/MainActivity.java
@@ -18,11 +18,13 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.support.v4.widget.DrawerLayout;
+import android.view.WindowManager;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.project.squirrelobserver.util.Behavior;
 import com.project.squirrelobserver.util.FileParser;
@@ -471,20 +473,25 @@ public class MainActivity extends ActionBarActivity
                                 getResources().getString(R.string.ao_observer_id_picker_dialog_confirm),
                                 new DialogInterface.OnClickListener() {
                                     public void onClick(DialogInterface dialog, int id) {
+                                        if (observerIDEditText.getText().toString().equals("")) {
+                                            observerIDEditText.requestFocus();
+                                            Toast toast = Toast.makeText(getApplicationContext(), "Observer ID is mandatory", Toast.LENGTH_SHORT);
+                                            toast.show();
+                                        } else {
+                                            // Start Record Activity
+                                            Intent intent = new Intent(activity, RecordActivity.class);
+                                            Record record = new Record(observerIDEditText.getText().toString(), true);
 
-                                        // Start Record Activity
-                                        Intent intent = new Intent(activity, RecordActivity.class);
-                                        Record record = new Record(observerIDEditText.getText().toString(), true);
+                                            long intervalInMillis = 0;
+                                            Bundle params = new Bundle();
+                                            params.putBoolean("startTimer", false);
+                                            params.putLong("scanInterval", intervalInMillis);
+                                            intent.putExtras(params);
 
-                                        long intervalInMillis = 0;
-                                        Bundle params = new Bundle();
-                                        params.putBoolean("startTimer", false);
-                                        params.putLong("scanInterval", intervalInMillis);
-                                        intent.putExtras(params);
+                                            GlobalVariables.currentRecord = record;
 
-                                        GlobalVariables.currentRecord = record;
-
-                                        startActivity(intent);
+                                            startActivity(intent);
+                                        }
                                     }
                                 })
                         .setNegativeButton(

--- a/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordActivity.java
+++ b/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordActivity.java
@@ -91,6 +91,7 @@ public  class RecordActivity
             header.setText(getResources().getString(R.string.record_activity_scan_label));
         } else {
             header.setText(getResources().getString(R.string.record_activity_all_occurrences_label));
+            mChronometer.setVisibility(View.GONE);
         }
 
         // Setup tabs
@@ -161,9 +162,7 @@ public  class RecordActivity
 
         tabHost.setCurrentTab(0);
 
-        if(!mChronometer.equals(null)) {
-            mChronometer.start();
-        }
+        mChronometer.start();
     }
 
     public void switchTabView(int position) {


### PR DESCRIPTION
Observer ID is now required to launch the AO record activity. If it is empty, it will toast a message to the user stating so and close the dialog
