### PR TITLE
Non-AO behavior buttons now get hidden when switching to AO

### DIFF
--- a/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordActivity.java
+++ b/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordActivity.java
@@ -61,6 +61,10 @@ public  class RecordActivity
             public void onClick(View v) {
                 Switch toggle = (Switch) v;
                 scanMode = toggle.isChecked();
+                if (behaviorTabActivity != null) {
+                    behaviorTabActivity.toggleMode(scanMode);
+                    behaviorTabActivity.onContentChanged();
+                }
                 if (toggle.isChecked()) {
                     toggle.setText(R.string.record_activity_scan_label);
                     if(actorTabActivity != null) {

--- a/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordBehaviorTabActivity.java
+++ b/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordBehaviorTabActivity.java
@@ -201,9 +201,6 @@ public  class RecordBehaviorTabActivity
     public void onResume() {
         super.onResume();
 
-//        gridView = (GridView) findViewById(R.id.behavior_grid_id);
-//        gridViewFrequent = (GridView) findViewById(R.id.behavior_grid_recent_id);
-
         if (gridView != null && gridViewFrequent != null) {
             gridView.invalidateViews();
             gridViewFrequent.invalidateViews();
@@ -277,14 +274,8 @@ public  class RecordBehaviorTabActivity
             if (!behavior.desc.toLowerCase().contains(filter.toLowerCase())) {
 
                 button.setVisibility(View.GONE);
-            } else {
-                if(isScanMode) {
-                    button.setVisibility(View.VISIBLE);
-                } else {
-                    if(((Behavior) button.getTag()).isAO) {
-                        button.setVisibility(View.VISIBLE);
-                    }
-                }
+            } else if (isScanMode || (!isScanMode && behavior.isAO)) {
+                button.setVisibility(View.VISIBLE);
             }
         }
     }
@@ -292,9 +283,6 @@ public  class RecordBehaviorTabActivity
     public void toggleMode(boolean scanMode) {
         toggleHideNonAOBehaviors(scanMode, list);
         toggleHideNonAOBehaviors(scanMode, listFrequent);
-
-//        final GridView gridView = (GridView) findViewById(R.id.behavior_grid_id);
-//        final GridView gridViewRecent = (GridView) findViewById(R.id.behavior_grid_recent_id);
 
         if (gridView != null && gridViewFrequent != null) {
             gridView.invalidateViews();
@@ -315,11 +303,9 @@ public  class RecordBehaviorTabActivity
             if(behavior == null)
                 return;
 
-            if (!scanMode) {
-                if (!behavior.isAO)
+            if (!scanMode && !behavior.isAO) {
                     button.setVisibility(View.GONE);
             } else {
-                if (!behavior.isAO)
                     button.setVisibility(View.VISIBLE);
             }
         }

--- a/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordBehaviorTabActivity.java
+++ b/app/src/main/java/com/project/squirrelobserver/squirrelObserver/RecordBehaviorTabActivity.java
@@ -14,6 +14,7 @@ import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.GridView;
 import android.widget.LinearLayout;
+import android.widget.Switch;
 import android.widget.ToggleButton;
 
 import com.project.squirrelobserver.R;
@@ -32,6 +33,8 @@ public  class RecordBehaviorTabActivity
 
     private final ArrayList<ToggleButton> list = new ArrayList<ToggleButton>();
     private final ArrayList<ToggleButton> listFrequent = new ArrayList<ToggleButton>();
+    private GridView gridView = null;
+    private GridView gridViewFrequent = null;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -47,8 +50,8 @@ public  class RecordBehaviorTabActivity
 
             LinearLayout linearLayout = (LinearLayout) findViewById(R.id.behaviorsTabLinearLayout);
 
-            final GridView gridView = new GridView(RecordBehaviorTabActivity.this);
-            final GridView gridViewFrequent = new GridView(RecordBehaviorTabActivity.this);
+            gridView = new GridView(RecordBehaviorTabActivity.this);
+            gridViewFrequent = new GridView(RecordBehaviorTabActivity.this);
 
             // Loop to run through all buttons
             for (int i = 0; i < GlobalVariables.behaviors.size(); i++) {
@@ -116,7 +119,10 @@ public  class RecordBehaviorTabActivity
                         gridView.invalidateViews();
                     }
                 });
-
+                if (!behavior.isAO
+                        && !recordActivity.scanMode) {
+                    button.setVisibility(View.GONE);
+                }
                 // Add the first four buttons to the frequentLayout
                 if (i < 4) {
                     listFrequent.add(button);
@@ -188,18 +194,19 @@ public  class RecordBehaviorTabActivity
                 public void onTextChanged(CharSequence s, int start, int before, int count) { }
             });
         }
+
     }
 
     @Override
     public void onResume() {
         super.onResume();
 
-        final GridView gridView = (GridView) findViewById(R.id.behavior_grid_id);
-        final GridView gridViewRecent = (GridView) findViewById(R.id.behavior_grid_recent_id);
+//        gridView = (GridView) findViewById(R.id.behavior_grid_id);
+//        gridViewFrequent = (GridView) findViewById(R.id.behavior_grid_recent_id);
 
-        if (gridView != null && gridViewRecent != null) {
+        if (gridView != null && gridViewFrequent != null) {
             gridView.invalidateViews();
-            gridViewRecent.invalidateViews();
+            gridViewFrequent.invalidateViews();
         }
     }
 
@@ -255,6 +262,8 @@ public  class RecordBehaviorTabActivity
         if (buttons == null)
             return;
 
+        boolean isScanMode = ((Switch)getParent().findViewById(R.id.modeToggle)).isChecked();
+
         for (int i = 0; i < buttons.size(); i++) {
 
             ToggleButton button = buttons.get(i);
@@ -269,8 +278,49 @@ public  class RecordBehaviorTabActivity
 
                 button.setVisibility(View.GONE);
             } else {
+                if(isScanMode) {
+                    button.setVisibility(View.VISIBLE);
+                } else {
+                    if(((Behavior) button.getTag()).isAO) {
+                        button.setVisibility(View.VISIBLE);
+                    }
+                }
+            }
+        }
+    }
 
-                button.setVisibility(View.VISIBLE);
+    public void toggleMode(boolean scanMode) {
+        toggleHideNonAOBehaviors(scanMode, list);
+        toggleHideNonAOBehaviors(scanMode, listFrequent);
+
+//        final GridView gridView = (GridView) findViewById(R.id.behavior_grid_id);
+//        final GridView gridViewRecent = (GridView) findViewById(R.id.behavior_grid_recent_id);
+
+        if (gridView != null && gridViewFrequent != null) {
+            gridView.invalidateViews();
+            gridViewFrequent.invalidateViews();
+        }
+    }
+
+    private void toggleHideNonAOBehaviors(boolean scanMode, ArrayList<ToggleButton> buttons) {
+        if(buttons == null)
+            return;
+
+        for(int i=0; i < buttons.size(); i++) {
+            ToggleButton button = buttons.get(i);
+            if (button == null)
+                return;
+
+            Behavior behavior = (Behavior) button.getTag();
+            if(behavior == null)
+                return;
+
+            if (!scanMode) {
+                if (!behavior.isAO)
+                    button.setVisibility(View.GONE);
+            } else {
+                if (!behavior.isAO)
+                    button.setVisibility(View.VISIBLE);
             }
         }
     }

--- a/app/src/main/res/layout/activity_record.xml
+++ b/app/src/main/res/layout/activity_record.xml
@@ -38,6 +38,8 @@
                 android:layout_width="150dp"
                 android:layout_height="wrap_content"
                 android:showText="false"
+                android:textOff=""
+                android:textOn=""
                 android:layout_weight="1"
                 android:id="@+id/modeToggle"
                 android:textAlignment="center" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,7 +50,7 @@
 
     <string name="record_activity_end_button">End</string>
     <string name="record_activity_scan_label">Scan</string>
-    <string name="record_activity_all_occurrences_label">All Occurrences</string>
+    <string name="record_activity_all_occurrences_label">A-O</string>
     <string name="record_activity_filter_hint">Filter</string>
 
     <string name="import_export_location_label">Location File:</string>


### PR DESCRIPTION
When switching to AO mode, only the buttons related to the AO behaviors will be shown in the Behaviors tab.

Also, the Behaviors CSV file import now requires a boolean Is AO column, which was required anyway.
