### PR TITLE
AO List no longer clears when switching between import setup

### DIFF
--- a/app/src/main/java/com/project/squirrelobserver/fragments/ImportExportFragment.java
+++ b/app/src/main/java/com/project/squirrelobserver/fragments/ImportExportFragment.java
@@ -70,7 +70,6 @@ public class ImportExportFragment extends Fragment {
             TextView behaviorsLabel = (TextView) view.findViewById(R.id.behaviorsFileName);
             behaviorsLabel.setText(GlobalVariables.behaviorsCSVPath.substring(
                     GlobalVariables.behaviorsCSVPath.lastIndexOf("/") + 1));
-            GlobalVariables.aoBehaviors = null;
         }
 
         return view;

--- a/app/src/main/java/com/project/squirrelobserver/util/FileParser.java
+++ b/app/src/main/java/com/project/squirrelobserver/util/FileParser.java
@@ -201,7 +201,7 @@ public class FileParser {
             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
 
             String line;
-
+            GlobalVariables.aoBehaviors = null;
             // Skip first line, it contains the column headers
             reader.readLine();
 
@@ -237,7 +237,6 @@ public class FileParser {
                     } catch (Exception e) { }
                 }
             }
-            GlobalVariables.aoBehaviors = null;
             return true;
 
         } catch (Exception e) {


### PR DESCRIPTION
Just removed a nullification of the aoBehaviors list and added it into the file parsing.
