### PR TITLE
Was erroring because of the column name. Content Providers now work

### DIFF
--- a/app/src/main/java/com/project/squirrelobserver/squirrelObserver/MainActivity.java
+++ b/app/src/main/java/com/project/squirrelobserver/squirrelObserver/MainActivity.java
@@ -136,7 +136,7 @@ public class MainActivity extends ActionBarActivity
     private void showFileChooser(int selectCode) {
 
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.setType("text/csv");
+        intent.setType("*/*");
         intent.addCategory(Intent.CATEGORY_OPENABLE);
 
         try {

--- a/app/src/main/java/com/project/squirrelobserver/util/Utils.java
+++ b/app/src/main/java/com/project/squirrelobserver/util/Utils.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.provider.OpenableColumns;
 import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
@@ -152,15 +153,15 @@ public class Utils {
     public static String getPath(Context context, Uri uri) {
 
         if ("content".equalsIgnoreCase(uri.getScheme())) {
-            String[] projection = {MediaStore.Files.FileColumns.DATA, MediaStore.Files.FileColumns.DISPLAY_NAME};//{ "_data" };
+            String[] projection = {MediaStore.Files.FileColumns.DATA, MediaStore.Files.FileColumns.DISPLAY_NAME, MediaStore.Files.FileColumns.MIME_TYPE};//{ "_data" };
             Cursor cursor = null;
             String displayName;
             String destination;
             try {
-                cursor = context.getContentResolver().query(uri, projection, null, null, null);
+                cursor = context.getContentResolver().query(uri, null, null, null, null);
 
                 if (cursor.moveToFirst()) {
-                    displayName = cursor.getString(1);
+                    displayName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
                     destination = GlobalVariables.exportDownloadPath + displayName;//context.getFilesDir().getPath() + "/" + displayName;
                     String extension = displayName.substring(displayName.lastIndexOf(".")+1);
 

--- a/app/src/main/java/com/project/squirrelobserver/util/Utils.java
+++ b/app/src/main/java/com/project/squirrelobserver/util/Utils.java
@@ -153,7 +153,6 @@ public class Utils {
     public static String getPath(Context context, Uri uri) {
 
         if ("content".equalsIgnoreCase(uri.getScheme())) {
-            String[] projection = {MediaStore.Files.FileColumns.DATA, MediaStore.Files.FileColumns.DISPLAY_NAME, MediaStore.Files.FileColumns.MIME_TYPE};//{ "_data" };
             Cursor cursor = null;
             String displayName;
             String destination;
@@ -162,7 +161,7 @@ public class Utils {
 
                 if (cursor.moveToFirst()) {
                     displayName = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
-                    destination = GlobalVariables.exportDownloadPath + displayName;//context.getFilesDir().getPath() + "/" + displayName;
+                    destination = GlobalVariables.exportDownloadPath + displayName;
                     String extension = displayName.substring(displayName.lastIndexOf(".")+1);
 
                     if("csv".equalsIgnoreCase(extension)) {
@@ -192,10 +191,7 @@ public class Utils {
                     return destination;
                 }
 
-            } catch (Exception e) {
-                String error = e.toString();
-                e.printStackTrace();
-            }
+            } catch (Exception e) { }
 
         } else if ("file".equalsIgnoreCase(uri.getScheme())) {
 


### PR DESCRIPTION
Set file type for picker to _/_ so that all content providers will be shown. Type checking happens programmatically.
Changed the Column used to get the display name of the file selected needed to be OpenableColumns.DisplayName instead of MediaStore.
